### PR TITLE
Added each method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -7,3 +7,32 @@ Code is written using the Node-style Common JS module style and built using brow
 ## Testing
 Testing is done using mocha with chai expect syntax.
 The browser used to run the tests is phantomjs.
+
+- [Methods](#methods)
+  - [Each](#each)
+
+## Methods
+
+### Each
+``` javascript
+	dom().each(iteratorFN[, thisArg]);
+```
+This method will call an interator function for each element in the collection. It will pass the interator method the current element being iterated and its index. If the iterator returns false it will abort the iteration. If an optional scope object is passed this will be set to the iterators `this` property, otherwise it will be set to the current `dombuster` object.
+Accepts: interator [fn], scope [object]
+
+```javascript
+	var testScope = {
+		hi: 'you guys'
+	};
+
+	dom()
+		.create('<a>test</a>')
+		.create('<a>test2</a>')
+		.create('<a>test3</a>')
+		.each(function(item, index){
+			console.log(item.innerHTML, index, this.hi);
+
+			if(item.innerHTML === 'test2')
+				return false; //abort the iteration on the second item
+		}, testScope);
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,14 +6,37 @@ var Dom = function (elements) {
         return new Dom(elements);
     }
 
-    this.elements = elements;
+    this.elements = elements || [];
+    this.document = document;
 };
 
 Dom.prototype.create = function (elementString) {
-    var tmp            = document.implementation.createHTMLDocument();
+    var tmp            = this.document.implementation.createHTMLDocument();
     tmp.body.innerHTML = elementString;
-    return new Dom(tmp.body.children);
+
+    this.elements.push(tmp.body.children[0]);
+    return this;
 };
+
+/*
+	Will call the iterator method over each element in the collection.
+	If the interator returns false the loop will be aborted.
+	If an optional scope object is passed it will be set to the interator's this argument
+*/
+Dom.prototype.each = function(iterator, scope){
+	if(!(iterator instanceof Function))
+		return this;
+
+	for(var i = 0; i < this.elements.length; i++){
+		var fnScope = scope || this,
+			fn = iterator.bind(fnScope, this.elements[i], i);
+
+		if(fn() === false)
+			break;
+	}
+
+	return this;
+}
 
 // TODO: Creare a new work item for this
 //Dom.prototype.find = function (selector) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ var Dom = function (elements) {
 };
 
 Dom.prototype.create = function (elementString) {
-    var tmp            = this.document.implementation.createHTMLDocument();
+    var tmp = this.document.implementation.createHTMLDocument();
     tmp.body.innerHTML = elementString;
 
     this.elements.push(tmp.body.children[0]);
@@ -23,20 +23,26 @@ Dom.prototype.create = function (elementString) {
 	If the interator returns false the loop will be aborted.
 	If an optional scope object is passed it will be set to the interator's this argument
 */
-Dom.prototype.each = function(iterator, scope){
-	if(!(iterator instanceof Function))
-		return this;
+Dom.prototype.each = function (iterator, scope) {
+    if (!(iterator instanceof Function)) {
+        return this;
+    }
 
-	for(var i = 0; i < this.elements.length; i++){
-		var fnScope = scope || this,
-			fn = iterator.bind(fnScope, this.elements[i], i);
+    var i,
+        fnScope,
+        fn;
 
-		if(fn() === false)
-			break;
-	}
+    for (i = 0; i < this.elements.length; i++) {
+        fnScope = scope || this;
+        fn = iterator.bind(fnScope, this.elements[i], i);
 
-	return this;
-}
+        if (fn() === false) {
+            break;
+        }
+    }
+
+    return this;
+};
 
 // TODO: Creare a new work item for this
 //Dom.prototype.find = function (selector) {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "scripts": {
     "build": "browserify lib/index.js > dist/dombuster.js",
+    "lint": "jscs lib/ test/lib/ && jshint lib/ test/lib/",
     "test:build": "browserify test/index.js > test/tests.js",
     "test:run": "mocha-phantomjs test/runner.html",
-    "test": "npm run test:build && npm run test:run"
+    "test": "npm run lint && npm run test:build && npm run test:run"
   },
   "repository": {
     "type": "git",
@@ -22,6 +23,8 @@
   "devDependencies": {
     "browserify": "9.0.8",
     "chai": "^3.0.0",
+    "jscs": "^1.13.1",
+    "jshint": "^2.8.0",
     "mocha": "^2.2.5",
     "mocha-phantomjs": "^3.5.3",
     "phantomjs": "^1.9.17"

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -5,7 +5,7 @@ var dom    = require('./../../lib/index'),
 
 describe('create', function () {
     it('creates a dom object from a string', function () {
-        var anchorText = dom(document)
+        var anchorText = dom()
                             .create('<a>Text</a>')
                             .elements[0]
                             .innerHTML;
@@ -13,6 +13,47 @@ describe('create', function () {
         expect(anchorText).to.equal('Text');
     });
 });
+
+describe('each', function(){
+	it('iterates each created element', function(){
+		var elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
+		dom()
+			.create(elements[0])
+			.create(elements[1])
+			.create(elements[2])
+			.each(function(elem, index){
+				expect(elem.outerHTML).to.equal(elements[index]);
+			});
+	});
+	it('sets correct scope', function(){
+		function testScope(){
+
+		}
+
+		dom()
+			.create('<a>test</a>')
+			.each(function(){
+				expect(this).to.be.an.instanceof(testScope);
+			}, new testScope());
+	});
+	it('aborts loop', function(){
+		var index,
+			elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
+
+		dom()
+			.create(elements[0])
+			.create(elements[1])
+			.create(elements[2])
+			.each(function(item, i){
+				index = i;
+
+				if(i == 1)
+					return false;
+			});
+
+			expect(index).to.equal(1);
+	});
+})
 // TODO: Create a new work item for this
 //describe('find', function () {
 //    it('finds an element ', function () {

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -1,59 +1,61 @@
 'use strict';
 
-var dom    = require('./../../lib/index'),
+var dom = require('./../../lib/index'),
     expect = require('chai').expect;
 
 describe('create', function () {
     it('creates a dom object from a string', function () {
         var anchorText = dom()
-                            .create('<a>Text</a>')
-                            .elements[0]
-                            .innerHTML;
+            .create('<a>Text</a>')
+            .elements[0]
+            .innerHTML;
 
         expect(anchorText).to.equal('Text');
     });
 });
 
-describe('each', function(){
-	it('iterates each created element', function(){
-		var elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
-		dom()
-			.create(elements[0])
-			.create(elements[1])
-			.create(elements[2])
-			.each(function(elem, index){
-				expect(elem.outerHTML).to.equal(elements[index]);
-			});
-	});
-	it('sets correct scope', function(){
-		function testScope(){
+describe('each', function () {
+    it('iterates each created element', function () {
+        var elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
+        dom()
+            .create(elements[0])
+            .create(elements[1])
+            .create(elements[2])
+            .each(function (elem, index) {
+                expect(elem.outerHTML).to.equal(elements[index]);
+            });
+    });
 
-		}
+    it('correctly sets scope when passed in as an argument', function () {
+        function TestScope() {
 
-		dom()
-			.create('<a>test</a>')
-			.each(function(){
-				expect(this).to.be.an.instanceof(testScope);
-			}, new testScope());
-	});
-	it('aborts loop', function(){
-		var index,
-			elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
+        }
 
-		dom()
-			.create(elements[0])
-			.create(elements[1])
-			.create(elements[2])
-			.each(function(item, i){
-				index = i;
+        dom()
+            .create('<a>test</a>')
+            .each(function () {
+                expect(this).to.be.an.instanceof(TestScope);
+            }, new TestScope());
+    });
+    it('correcly breaks loop if false returned', function () {
+        var index,
+            elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
 
-				if(i == 1)
-					return false;
-			});
+        dom()
+            .create(elements[0])
+            .create(elements[1])
+            .create(elements[2])
+            .each(function (item, i) {
+                index = i;
 
-			expect(index).to.equal(1);
-	});
-})
+                if (i === 1) {
+                    return false;
+                }
+            });
+
+        expect(index).to.equal(1);
+    });
+});
 // TODO: Create a new work item for this
 //describe('find', function () {
 //    it('finds an element ', function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -12,7 +12,7 @@ var Dom = function (elements) {
 };
 
 Dom.prototype.create = function (elementString) {
-    var tmp            = this.document.implementation.createHTMLDocument();
+    var tmp = this.document.implementation.createHTMLDocument();
     tmp.body.innerHTML = elementString;
 
     this.elements.push(tmp.body.children[0]);
@@ -24,20 +24,26 @@ Dom.prototype.create = function (elementString) {
 	If the interator returns false the loop will be aborted.
 	If an optional scope object is passed it will be set to the interator's this argument
 */
-Dom.prototype.each = function(iterator, scope){
-	if(!(iterator instanceof Function))
-		return this;
+Dom.prototype.each = function (iterator, scope) {
+    if (!(iterator instanceof Function)) {
+        return this;
+    }
 
-	for(var i = 0; i < this.elements.length; i++){
-		var fnScope = scope || this,
-			fn = iterator.bind(fnScope, this.elements[i], i);
+    var i,
+        fnScope,
+        fn;
 
-		if(fn() === false)
-			break;
-	}
+    for (i = 0; i < this.elements.length; i++) {
+        fnScope = scope || this;
+        fn = iterator.bind(fnScope, this.elements[i], i);
 
-	return this;
-}
+        if (fn() === false) {
+            break;
+        }
+    }
+
+    return this;
+};
 
 // TODO: Creare a new work item for this
 //Dom.prototype.find = function (selector) {
@@ -7069,60 +7075,62 @@ require('../test/lib/index');
 },{"../test/lib/index":42}],42:[function(require,module,exports){
 'use strict';
 
-var dom    = require('./../../lib/index'),
+var dom = require('./../../lib/index'),
     expect = require('chai').expect;
 
 describe('create', function () {
     it('creates a dom object from a string', function () {
         var anchorText = dom()
-                            .create('<a>Text</a>')
-                            .elements[0]
-                            .innerHTML;
+            .create('<a>Text</a>')
+            .elements[0]
+            .innerHTML;
 
         expect(anchorText).to.equal('Text');
     });
 });
 
-describe('each', function(){
-	it('iterates each created element', function(){
-		var elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
-		dom()
-			.create(elements[0])
-			.create(elements[1])
-			.create(elements[2])
-			.each(function(elem, index){
-				expect(elem.outerHTML).to.equal(elements[index]);
-			});
-	});
-	it('sets correct scope', function(){
-		function testScope(){
+describe('each', function () {
+    it('iterates each created element', function () {
+        var elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
+        dom()
+            .create(elements[0])
+            .create(elements[1])
+            .create(elements[2])
+            .each(function (elem, index) {
+                expect(elem.outerHTML).to.equal(elements[index]);
+            });
+    });
 
-		}
+    it('correctly sets scope when passed in as an argument', function () {
+        function TestScope() {
 
-		dom()
-			.create('<a>test</a>')
-			.each(function(){
-				expect(this).to.be.an.instanceof(testScope);
-			}, new testScope());
-	});
-	it('aborts loop', function(){
-		var index,
-			elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
+        }
 
-		dom()
-			.create(elements[0])
-			.create(elements[1])
-			.create(elements[2])
-			.each(function(item, i){
-				index = i;
+        dom()
+            .create('<a>test</a>')
+            .each(function () {
+                expect(this).to.be.an.instanceof(TestScope);
+            }, new TestScope());
+    });
+    it('correcly breaks loop if false returned', function () {
+        var index,
+            elements = ['<a>Text1</a>', '<a>Text2</a>', '<a>Text3</a>'];
 
-				if(i == 1)
-					return false;
-			});
+        dom()
+            .create(elements[0])
+            .create(elements[1])
+            .create(elements[2])
+            .each(function (item, i) {
+                index = i;
 
-			expect(index).to.equal(1);
-	});
-})
+                if (i === 1) {
+                    return false;
+                }
+            });
+
+        expect(index).to.equal(1);
+    });
+});
 // TODO: Create a new work item for this
 //describe('find', function () {
 //    it('finds an element ', function () {


### PR DESCRIPTION
With reference to issue #2 

This will add an each method. The user calls .each with an iterator fn, the iterator will be called with the current item being iterated and its index. An option scope object can be passed and will be set to the iterators this property.

NOTE:

The dombuster constructor and create methods has to be changed. 
Constructor:
You no longer instantiate a `Dom` object with an element. You can now instantiate it with either an array of elements or nothing. It has an internal document object and will default the elements collection to an empty array if nothing is passed.
Create:
This no longer returns a new Dom object with the created element in the elements collection. Instead it returns the current instance of the Dom object and appends the created element to the existing elements collection. Without this the following would happen:

``` javascript
dom()
.create('<a>test1</a>')
.create('<a>test2</>')
.create('<a>test3</a>')
.each(function(item, index){
    console.log(item.innerHTML); //logs test3
    console.log(index); // logs 0
});
```

This create method will require further work however in the future as,

``` javascript
dom()
.create('<a>test</a><a>test2</a>');
``
Will only actually add the first anchor tag to the collection, ill will not merge both elements into the collection.
```
